### PR TITLE
http -> https

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -24,5 +24,5 @@ title: Chat
 </div>
 
 <script type="text/javascript">
-    $("#chat").attr("src", "http://webchat.quakenet.org/?nick=Deuce" + Math.floor((Math.random() * 1000) + 1) + "&channels=buildandshoot&lightness=-95&thue=0&tlightness=100&tsaturation=-100&prompt=0");
+    $("#chat").attr("src", "https://webchat.quakenet.org/?nick=Deuce" + Math.floor((Math.random() * 1000) + 1) + "&channels=buildandshoot&lightness=-95&thue=0&tlightness=100&tsaturation=-100&prompt=0");
 </script>


### PR DESCRIPTION
QuakeNet offers HTTPS and the box doesn't load automatically with Chrome since it is paranoid, so this should fix that problem.