### PR TITLE
Fix OpenSpades Windows version not showing for download

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -417,7 +417,7 @@ function getOpenspadesReleases(callback, tag) {
         for(var i = 0; i < response.assets.length; i++) {
             var asset = response.assets[i];
             
-            if (asset.content_type == "application/zip") {
+            if (asset.content_type == "application/zip" || asset.content_type == "application/x-zip-compressed") {
 
                 var platform;
 


### PR DESCRIPTION
Windows version had a different `content_type` which the script didn't check for, therefore only showing the OS X version. I added an option to the `content_type` check.