### PR TITLE
add download page section for piqueserver

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -372,6 +372,7 @@ var PLATFORM = {
     WINDOWS : {value: 0, name: "Windows", fontawesome: "windows"}, 
     OSX : {value: 1, name: "OSX", fontawesome: "apple"},  
     LINUX : {value: 2, name: "Linux", fontawesome: "linux"}, 
+    MULTI : {value: 3, name: "Multiplatform", fontawesome: "server"},
 };
 
 function Release(name, version, updated, platform, url) {
@@ -466,6 +467,26 @@ function getPysnipReleases(callback, tag) {
         return callback(releases, tag);
     });
 }
+
+function getPiqueserverReleases(callback, tag) {
+    var releases = [];
+
+    $.get('https://api.github.com/repos/piqueserver/piqueserver/releases', function (response) {
+
+        var linux = [];
+
+        for(var i = 0; i < 2; i++) {
+
+            var release = response[i];
+
+            var release = new Release(release.name, release.tag_name, release.created_at, PLATFORM.MULTI, release.html_url);
+            releases.push(release);
+        }
+
+        return callback(releases, tag);
+    });
+}
+
 
 function getVoxlapReleases(callback, tag) {
     var releases = [];

--- a/download/index.html
+++ b/download/index.html
@@ -39,6 +39,12 @@ js:
                 <p>PySnip is a robust, open-source and cross-platform server implementation for Ace of Spades. It is fully customizable with extensions and scripts.</p>
                 <div id="pysnip-container" class="download-container"></div>
             </div>
+            <div class="row no-horizontal-margin">
+                <h3 class="text-center">Piqueserver</h3>
+                <div class="heading-hr"></div>
+                <p>Piqueserver is an actively maintained fork of PySnip, bringing more stability, bugfixes, and new features.</p>
+                <div id="piqueserver-container" class="download-container"></div>
+            </div>
         </div>
 
         <div class="col-md-2 hidden-sm" data-adblock-class="hidden-xs">
@@ -188,6 +194,13 @@ $(document).ready(function () {
 
         ['Python 2.7']);
     getPysnipReleases(gotReleases, "pysnip");
+
+    populateDownloads("piqueserver",
+        ['Python 2.7 (v0.1.3 and earlier)',
+         'Python 3.4 (newer releases)'],
+
+        ['>= Python 3.4']);
+    getPiqueserverReleases(gotReleases, "piqueserver");
 
     populateDownloads("voxlap", 
         ['Your grandmother’s rig can run this game.'],


### PR DESCRIPTION
This adds an extra section to the download page of the website for [piqueserver](https://github.com/piqueserver/piqueserver/).

Piqueserver is a relatively new addition to the community, but has already seen many improvements and bugfixes. It would be great if this could be featured on buildandshoot.com!

Thanks.